### PR TITLE
INTYGFV-11847: Lagt till pattern så att vi även extraherar typ (pdfpr…

### DIFF
--- a/logstash/logs/webcert-monitoring.log
+++ b/logstash/logs/webcert-monitoring.log
@@ -92,3 +92,7 @@ INFO: Redis master running at 127.0.0.1:6379, starting Sentinel listeners...
 Feb 14, 2019 5:41:42 PM redis.clients.jedis.JedisSentinelPool initSentinels
 Feb 14, 2019 5:41:42 PM redis.clients.jedis.JedisSentinelPool initPool
 INFO: Created JedisPool to master at 127.0.0.1:6379
+2019-06-05 12:46:03.301 INFO  [monitoring,0fee835f-fe93-4252-a6f8-88e81ea352d4,Xwlm9Yvk,TSTNMT2321000156-1079,TSTNMT2321000156-1077,NORMAL,LAKARE] --- s.i.i.w.w.s.m.MonitoringLogService : INTYG_PRINT_PDF Intyg '3fee835f-fe93-4252-a6f8-88e81ea352d4' of type 'ag114' was printed as PDF with 'MINIMAL' content
+
+
+

--- a/logstash/patterns/webcert
+++ b/logstash/patterns/webcert
@@ -15,6 +15,7 @@ WC__QA_PARSE (%{WC__QUESTION_RECEIVED}|%{WC__QUESTION_RECEIVED_COMPLETION}|%{WC_
 WC__INTYG_READ Intyg '%{UUID:intygid}' of type '%{NOTSPACE:intygtyp}' was read
 WC__INTYG_REVOKE_STATUS_READ Revoke status of Intyg '%{UUID:intygid}' of type '%{NOTSPACE:intygtyp}' was read.
 WC__INTYG_PRINT_PDF Intyg '%{UUID:intygid}' of type '%{NOTSPACE:intygtyp}' was printed as PDF
+WC__INTYG_PRINT_PDF_CONTENT Intyg '%{UUID:intygid}' of type '%{NOTSPACE:intygtyp}' was printed as PDF with '%{NOTSPACE:pdfprinttype}' content
 WC__INTYG_SIGNED Intyg '%{UUID:intygid}' of type '%{NOTSPACE:intygtyp}' signed by '%{USER:signer}' using scheme '%{DATA:scheme}' and relation code '%{DATA:relation}'
 WC__INTYG_REGISTERED Intyg '%{UUID:intygid}' of type '%{NOTSPACE:intygtyp}' registered with Intygstjänsten
 WC__INTYG_SENT Intyg '%{UUID:intygid}' sent to recipient '%{DATA:recipient}'
@@ -35,7 +36,7 @@ WC__UTKAST_READY_NOTIFICATION_SENT Utkast '%{UUID:intygid}' of type '%{NOTSPACE:
 WC__REVOKED_PRINT Revoked intyg '%{UUID:intygid}' of type '%{NOTSPACE:intygtyp}' printed
 WC__DIAGNOSKODVERK_CHANGED Diagnoskodverk changed for utkast '%{UUID:intygid}' of type '%{NOTSPACE:intygtyp}'
 WC__UTKAST_SIGN_FAILED Utkast '%{UUID:intygid}' failed signing process with message '%{DATA:message}'
-WC__INTYG_PARSE (%{WC__INTYG_READ}|%{WC__INTYG_REVOKE_STATUS_READ}|%{WC__INTYG_PRINT_PDF}|%{WC__INTYG_SIGNED}|%{WC__INTYG_REGISTERED}|%{WC__INTYG_SENT}|%{WC__INTYG_REVOKED}|%{WC__INTYG_COPIED}|%{WC__INTYG_COPIED_RENEWAL}|%{WC__INTYG_COPIED_REPLACEMENT}|%{WC__INTYG_COPIED_COMPLETION}|%{WC__UTKAST_READ}|%{WC__UTKAST_CREATED}|%{WC__UTKAST_EDITED}|%{WC__UTKAST_PATIENT_UPDATED}|%{WC__UTKAST_DELETED}|%{WC__UTKAST_PRINT}|%{WC__UTKAST_CONCURRENTLY_EDITED}|%{WC__UTKAST_REVOKED}|%{WC__UTKAST_READY_NOTIFICATION_SENT}|%{WC__REVOKED_PRINT}|%{WC__DIAGNOSKODVERK_CHANGED}|%{WC__UTKAST_SIGN_FAILED})
+WC__INTYG_PARSE (%{WC__INTYG_READ}|%{WC__INTYG_REVOKE_STATUS_READ}|%{WC__INTYG_PRINT_PDF_CONTENT}|%{WC__INTYG_PRINT_PDF}|%{WC__INTYG_SIGNED}|%{WC__INTYG_REGISTERED}|%{WC__INTYG_SENT}|%{WC__INTYG_REVOKED}|%{WC__INTYG_COPIED}|%{WC__INTYG_COPIED_RENEWAL}|%{WC__INTYG_COPIED_REPLACEMENT}|%{WC__INTYG_COPIED_COMPLETION}|%{WC__UTKAST_READ}|%{WC__UTKAST_CREATED}|%{WC__UTKAST_EDITED}|%{WC__UTKAST_PATIENT_UPDATED}|%{WC__UTKAST_DELETED}|%{WC__UTKAST_PRINT}|%{WC__UTKAST_CONCURRENTLY_EDITED}|%{WC__UTKAST_REVOKED}|%{WC__UTKAST_READY_NOTIFICATION_SENT}|%{WC__REVOKED_PRINT}|%{WC__DIAGNOSKODVERK_CHANGED}|%{WC__UTKAST_SIGN_FAILED})
 
 # ------------------------------------------------------------
 # WC__MAIL_PARSE


### PR DESCRIPTION
…inttype = FULL/MINIMAL) av utskrift av intyg iom uppdaterad monitoreringsloggning av intygsutskrifter. Det gamla patternet finns kvar för bakåtkompatabilitet.